### PR TITLE
Bump dependencies on CPLC 1.8

### DIFF
--- a/runtime-decompiler/pom.xml
+++ b/runtime-decompiler/pom.xml
@@ -131,17 +131,17 @@
         <dependency>
             <groupId>io.github.mkoncek</groupId>
             <artifactId>classpathless-compiler-api</artifactId>
-            <version>[1.0,)</version>
+            <version>[1.8,)</version>
         </dependency>
         <dependency>
             <groupId>io.github.mkoncek</groupId>
             <artifactId>classpathless-compiler-util</artifactId>
-            <version>[1.0,)</version>
+            <version>[1.8,)</version>
         </dependency>
         <dependency>
             <groupId>io.github.mkoncek</groupId>
             <artifactId>classpathless-compiler</artifactId>
-            <version>[1.7,)</version>
+            <version>[1.8,)</version>
         </dependency>
         <dependency>
             <groupId>com.google.code.gson</groupId>


### PR DESCRIPTION
Version 1.8 has just been released with a few changes in behaviour.
This PR is intended for you to see if there were no regressions.