### PR TITLE
Enable change of RSyntaxTextArea fontsize in runtime

### DIFF
--- a/runtime-decompiler/src/main/java/org/jrd/backend/data/Config.java
+++ b/runtime-decompiler/src/main/java/org/jrd/backend/data/Config.java
@@ -57,6 +57,7 @@ public final class Config {
     private static final String ADDITIONAL_SOURCE_PATH = "ADDITIONAL_SOURCE_PATH";
     private static final String ADDITIONAL_CLASS_PATH = "ADDITIONAL_CLASS_PATH";
     private static final String LOOK_AND_FEEL_KEY = "LOOK_AND_FEEL";
+    private static final String FONT_SIZE_KEY = "FONT_SIZE";
     //this is not persistent, is used for transfering detected value to compiler with other settings
     private Optional<Integer> sourceTargetValue;
     private FsAgent additionalClassPathAgent;
@@ -266,6 +267,13 @@ public final class Config {
         }
 
         return Collections.unmodifiableList(savedExtensions);
+    }
+    public float getFontSizeOverride() {
+        return ((Number)(configMap.getOrDefault(FONT_SIZE_KEY, 0))).floatValue();
+    }
+
+    public void setFontSizeOverride(int size) {
+        configMap.put(FONT_SIZE_KEY, size);
     }
 
     public String getCompilerArgsString() {

--- a/runtime-decompiler/src/main/java/org/jrd/backend/data/Config.java
+++ b/runtime-decompiler/src/main/java/org/jrd/backend/data/Config.java
@@ -5,6 +5,7 @@ import org.jrd.backend.communication.ErrorCandidate;
 import org.jrd.backend.communication.FsAgent;
 import org.jrd.backend.core.AgentRequestAction;
 import org.jrd.backend.core.Logger;
+import org.jrd.backend.data.cli.FontChangeListener;
 import org.jrd.backend.decompiling.ExpandableUrl;
 import org.jrd.frontend.utility.AgentApiGenerator;
 
@@ -40,6 +41,8 @@ public final class Config {
     private final Gson gson;
     private Map<String, Object> configMap;
 
+    private final List<FontChangeListener> rTextAreas = new ArrayList();
+
     private static final String CONFIG_PATH = Directories.getConfigDirectory() + File.separator + "config.json";
     public static final String AGENT_PATH_OVERWRITE_PROPERTY = "org.jrd.agent.jar";
     private static final String AGENT_PATH_KEY = "AGENT_PATH";
@@ -62,6 +65,7 @@ public final class Config {
     private Optional<Integer> sourceTargetValue;
     private FsAgent additionalClassPathAgent;
     private FsAgent additionalSourcePathAgent;
+
 
     public enum DepndenceNumbers {
         ENFORCE_ONE("This will pass only selected class to decompiler. Fastest, worst results, may have its weird usecase"),
@@ -604,6 +608,20 @@ public final class Config {
         static VminfoWithDuplicatedBytemanCompanion base64Deserialize(String base64Representation)
                 throws IOException, ClassNotFoundException {
             return (VminfoWithDuplicatedBytemanCompanion) Config.base64Deserialize(base64Representation);
+        }
+    }
+
+    public void registerFontListener(FontChangeListener fl) {
+        rTextAreas.add(fl);
+    }
+
+    public void unregisterFontListener(FontChangeListener fl) {
+        rTextAreas.remove(fl);
+    }
+
+    public void setFonts() {
+        for(FontChangeListener fl: rTextAreas) {
+            fl.adjustFont(getFontSizeOverride());
         }
     }
 }

--- a/runtime-decompiler/src/main/java/org/jrd/backend/data/cli/FontChangeListener.java
+++ b/runtime-decompiler/src/main/java/org/jrd/backend/data/cli/FontChangeListener.java
@@ -1,0 +1,7 @@
+package org.jrd.backend.data.cli;
+
+public interface FontChangeListener {
+
+    void adjustFont(float value);
+
+}

--- a/runtime-decompiler/src/main/java/org/jrd/backend/data/cli/Help.java
+++ b/runtime-decompiler/src/main/java/org/jrd/backend/data/cli/Help.java
@@ -282,6 +282,9 @@ public final class Help {
                     indent(1) + launcher(false) + "[" + HEX + "]" + " [file, file...]" +
                             " launches standalone hex (or text) editor/diff. Mighty diff. " + HEX + " suggests, how to open `file, file...`"
             );
+            System.out.println(
+                    indent(1) + launcher(false) + "[" + FS + "]" + " <class:path> will launch temporary filesystem based decompiler"
+            );
         }
 
         void printOptionsHeading();

--- a/runtime-decompiler/src/main/java/org/jrd/frontend/frame/main/decompilerview/TextWithControls.java
+++ b/runtime-decompiler/src/main/java/org/jrd/frontend/frame/main/decompilerview/TextWithControls.java
@@ -54,6 +54,7 @@ import org.jrd.backend.core.Logger;
 import org.jrd.backend.data.Config;
 import org.jrd.backend.data.VmInfo;
 import org.jrd.backend.data.VmManager;
+import org.jrd.backend.data.cli.FontChangeListener;
 import org.jrd.backend.decompiling.DecompilerWrapper;
 import org.jrd.backend.decompiling.PluginManager;
 import org.jrd.frontend.frame.hex.FeatureFullHex;
@@ -87,7 +88,7 @@ import org.kcc.wordsets.ConnectedKeywords;
 import org.kcc.wordsets.JrdApiKeywords;
 
 @SuppressWarnings("LineLength") // un-refactorable
-public class TextWithControls extends JPanel implements LinesProvider, ClasspathProvider, ExecuteMethodProvider, SaveProvider, UploadProvider {
+public class TextWithControls extends JPanel implements LinesProvider, ClasspathProvider, ExecuteMethodProvider, SaveProvider, UploadProvider, FontChangeListener {
 
     private final RSyntaxTextArea bytecodeSyntaxTextArea;
     private final SearchControlsPanel bytecodeSearchControls;
@@ -131,6 +132,8 @@ public class TextWithControls extends JPanel implements LinesProvider, Classpath
     }
 
     public TextWithControls(String title, String codeSelect, CodeCompletionType cct, ClassesAndMethodsProvider classesAndMethodsProvider) {
+        //FIXME unregister
+        Config.getConfig().registerFontListener(this);
         this.cct = cct;
         this.classesAndMethodsProvider = classesAndMethodsProvider;
         HexWithControls.initTabLayers(this, title);
@@ -370,6 +373,16 @@ public class TextWithControls extends JPanel implements LinesProvider, Classpath
             //belive or not, rsyntax are can throw exception form here, and asnothing expects that, it may be fatal
             ex.printStackTrace();
         }
+    }
+
+    @Override
+    public void adjustFont(float value) {
+        if (value > 0) {
+            bytecodeSyntaxTextArea.setFont(bytecodeSyntaxTextArea.getFont().deriveFont(value));
+        } else {
+            bytecodeSyntaxTextArea.setFont(new RSyntaxTextAreaWithCompletion().getFont());
+        }
+        bytecodeSyntaxTextArea.repaint();
     }
 
     public enum CodeCompletionType {

--- a/runtime-decompiler/src/main/java/org/jrd/frontend/frame/main/decompilerview/TextWithControls.java
+++ b/runtime-decompiler/src/main/java/org/jrd/frontend/frame/main/decompilerview/TextWithControls.java
@@ -132,7 +132,6 @@ public class TextWithControls extends JPanel implements LinesProvider, Classpath
     }
 
     public TextWithControls(String title, String codeSelect, CodeCompletionType cct, ClassesAndMethodsProvider classesAndMethodsProvider) {
-        //FIXME unregister
         Config.getConfig().registerFontListener(this);
         this.cct = cct;
         this.classesAndMethodsProvider = classesAndMethodsProvider;

--- a/runtime-decompiler/src/main/java/org/jrd/frontend/frame/main/decompilerview/TextWithControls.java
+++ b/runtime-decompiler/src/main/java/org/jrd/frontend/frame/main/decompilerview/TextWithControls.java
@@ -51,6 +51,7 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.jrd.backend.completion.ClassesAndMethodsProvider;
 import org.jrd.backend.completion.JrdCompletionSettings;
 import org.jrd.backend.core.Logger;
+import org.jrd.backend.data.Config;
 import org.jrd.backend.data.VmInfo;
 import org.jrd.backend.data.VmManager;
 import org.jrd.backend.decompiling.DecompilerWrapper;
@@ -238,6 +239,9 @@ public class TextWithControls extends JPanel implements LinesProvider, Classpath
 
     private RSyntaxTextArea createSrcTextArea() {
         final RSyntaxTextArea rst = new RSyntaxTextAreaWithCompletion();
+        if (Config.getConfig().getFontSizeOverride() > 0) {
+            rst.setFont(rst.getFont().deriveFont(Config.getConfig().getFontSizeOverride()));
+        }
         rst.addKeyListener(new MainRsyntaxKeyListener(rst));
         rst.setSyntaxEditingStyle(SyntaxConstants.SYNTAX_STYLE_JAVA);
         rst.setCodeFoldingEnabled(true);

--- a/runtime-decompiler/src/main/java/org/jrd/frontend/frame/settings/MiscellaneousSettingsPanel.java
+++ b/runtime-decompiler/src/main/java/org/jrd/frontend/frame/settings/MiscellaneousSettingsPanel.java
@@ -39,6 +39,8 @@ public class MiscellaneousSettingsPanel extends JPanel implements ChangeReporter
     private final JComboBox<String> lookAndFeel;
     private final JTextField srcPath;
     private final JTextField classPath;
+    private final JLabel fontSizeOverrideLabel = new JLabel("Set to non-zero to overwrite default font size in src editors");
+    private final JTextField fontSizeOverride = new JTextField("0");
     ButtonGroup additionalAgentPlace = new ButtonGroup();
     JRadioButton nothing = new JRadioButton("do nothing");
     JRadioButton add = new JRadioButton("add them to remote vms");
@@ -47,7 +49,7 @@ public class MiscellaneousSettingsPanel extends JPanel implements ChangeReporter
 
     public MiscellaneousSettingsPanel(
             boolean initialUseJavapSignatures, Config.DepndenceNumbers initialConfigNumbers, String cp, String sp,
-            boolean detectAutocompletion, Config.AdditionalAgentAction additionalAgentAction, final JFrame parent
+            boolean detectAutocompletion, Config.AdditionalAgentAction additionalAgentAction, int fontSizeOverride, final JFrame parent
     ) {
         miscSettingsLabel = new JLabel("Miscellaneous settings");
         this.setName(miscSettingsLabel.getText());
@@ -69,6 +71,8 @@ public class MiscellaneousSettingsPanel extends JPanel implements ChangeReporter
             }
         }
         lookAndFeel.addActionListener(new ChangeLafListener(parent));
+
+        this.fontSizeOverride.setText(String.valueOf(fontSizeOverride));
 
         initMainPanel(initialConfigNumbers, additionalAgentAction);
 
@@ -178,6 +182,12 @@ public class MiscellaneousSettingsPanel extends JPanel implements ChangeReporter
         gbc.gridwidth = 1;
         gbc.gridy = 10;
         mainPanel.add(lookAndFeel, gbc);
+        gbc.gridwidth = 1;
+        gbc.gridy = 11;
+        mainPanel.add(fontSizeOverrideLabel, gbc);
+        gbc.gridwidth = 1;
+        gbc.gridy = 12;
+        mainPanel.add(fontSizeOverride, gbc);
     }
 
     public boolean shouldUseJavapSignatures() {
@@ -202,6 +212,7 @@ public class MiscellaneousSettingsPanel extends JPanel implements ChangeReporter
         ChangeReporter.addCheckboxListener(listener, addAndSave);
         ChangeReporter.addCheckboxListener(listener, nothing);
         ChangeReporter.addCheckboxListener(listener, ask);
+        ChangeReporter.addTextChangeListener(listener, fontSizeOverride);
     }
 
     public String getAdditioalCP() {
@@ -210,6 +221,17 @@ public class MiscellaneousSettingsPanel extends JPanel implements ChangeReporter
 
     public String getAdditionalSP() {
         return srcPath.getText();
+    }
+
+    public int getFontSizeOverride() {
+        try {
+            return Integer.valueOf(fontSizeOverride.getText());
+        }catch (Exception ex) {
+            ex.printStackTrace();
+            JOptionPane.showMessageDialog(this, "Number expected: " + ex.toString());
+            fontSizeOverride.setText("0");
+            return 0;
+        }
     }
 
     public Config.AdditionalAgentAction getAdditionalAgentAction() {

--- a/runtime-decompiler/src/main/java/org/jrd/frontend/frame/settings/MiscellaneousSettingsPanel.java
+++ b/runtime-decompiler/src/main/java/org/jrd/frontend/frame/settings/MiscellaneousSettingsPanel.java
@@ -226,7 +226,7 @@ public class MiscellaneousSettingsPanel extends JPanel implements ChangeReporter
     public int getFontSizeOverride() {
         try {
             return Integer.valueOf(fontSizeOverride.getText());
-        }catch (Exception ex) {
+        } catch (Exception ex) {
             ex.printStackTrace();
             JOptionPane.showMessageDialog(this, "Number expected: " + ex.toString());
             fontSizeOverride.setText("0");

--- a/runtime-decompiler/src/main/java/org/jrd/frontend/frame/settings/SettingsView.java
+++ b/runtime-decompiler/src/main/java/org/jrd/frontend/frame/settings/SettingsView.java
@@ -154,5 +154,6 @@ public class SettingsView extends JDialog {
         } catch (IOException e) {
             Logger.getLogger().log(Logger.Level.ALL, e);
         }
+        config.setFonts();
     }
 }

--- a/runtime-decompiler/src/main/java/org/jrd/frontend/frame/settings/SettingsView.java
+++ b/runtime-decompiler/src/main/java/org/jrd/frontend/frame/settings/SettingsView.java
@@ -91,7 +91,7 @@ public class SettingsView extends JDialog {
         nestedJarsSettingsPanel.setMinimumSize(new Dimension(200, 200));
         miscSettingsPanel = new MiscellaneousSettingsPanel(
                 config.doUseJavapSignatures(), config.doDepndenceNumbers(), config.getAdditionalCP(), config.getAdditionalSP(),
-                config.doAutocompletion(), config.getAdditionalAgentAction(), (int)(config.getFontSizeOverride()), mainFrameView
+                config.doAutocompletion(), config.getAdditionalAgentAction(), (int) (config.getFontSizeOverride()), mainFrameView
         );
 
         for (

--- a/runtime-decompiler/src/main/java/org/jrd/frontend/frame/settings/SettingsView.java
+++ b/runtime-decompiler/src/main/java/org/jrd/frontend/frame/settings/SettingsView.java
@@ -91,7 +91,7 @@ public class SettingsView extends JDialog {
         nestedJarsSettingsPanel.setMinimumSize(new Dimension(200, 200));
         miscSettingsPanel = new MiscellaneousSettingsPanel(
                 config.doUseJavapSignatures(), config.doDepndenceNumbers(), config.getAdditionalCP(), config.getAdditionalSP(),
-                config.doAutocompletion(), config.getAdditionalAgentAction(), mainFrameView
+                config.doAutocompletion(), config.getAdditionalAgentAction(), (int)(config.getFontSizeOverride()), mainFrameView
         );
 
         for (
@@ -148,7 +148,7 @@ public class SettingsView extends JDialog {
         config.setAdditionalCP(miscSettingsPanel.getAdditioalCP());
         config.setAdditionalSP(miscSettingsPanel.getAdditionalSP());
         config.setAdditionalAgentAction(miscSettingsPanel.getAdditionalAgentAction());
-
+        config.setFontSizeOverride(miscSettingsPanel.getFontSizeOverride());
         try {
             config.saveConfigFile();
         } catch (IOException e) {


### PR DESCRIPTION
When used on presentations, the default font is to small.   hex can be changed in non-imbus LaF  from system, but RSyntaxTextArea is ignoring it always. This PR is  enabling manual resizing through config